### PR TITLE
Add language and include_extended_appinfo kwargs to GetOwnedGames

### DIFF
--- a/steampicker/Steam.py
+++ b/steampicker/Steam.py
@@ -21,6 +21,8 @@ class Steam:
             include_played_free_games = True,
             appids_filter             = None,
             include_free_sub          = True,
+            language                  = "en",
+            include_extended_appinfo  = True
         )
         return response['response']['games']
 


### PR DESCRIPTION
It did not work and threw errors until I included these variables. It was failing to pass `steam/webapi.py` check of `steam` python library on line 309

```
            if not optional and name not in kwargs and name != 'key':
                raise ValueError("Method requires %s to be set" % repr(name))
```